### PR TITLE
Add Shattered Sun Pendant of Acumen (Scryer/Aldor exalted neck for P5)

### DIFF
--- a/assets/js/App.vue
+++ b/assets/js/App.vue
@@ -578,6 +578,16 @@
                                 </select>
                             </div>
                             <div class="form-item">
+                                <label>
+                                    <span>Shattrath Faction</span>
+                                    <help>Controls the proc from Shattered Sun Pendant of Acumen necklace</help>
+                                </label>
+                                <select v-model="config.shatt_faction">
+                                    <option :value="factions.FACTION_ALDOR">Aldor</option>
+                                    <option :value="factions.FACTION_SCRYER">Scryer</option>
+                                </select>
+                            </div>
+                            <div class="form-item">
                                 <label>Talents (<a :href="config.talents" target="_blank">link</a>)</label>
                                 <input type="text" :value="config.talents" @input="onTalentsInput">
                             </div>
@@ -1456,6 +1466,7 @@
             var default_config = {
                 iterations: 30000,
                 race: 5,
+                shatt_faction: 0,
 
                 duration: 180,
                 duration_variance: 0,
@@ -1523,6 +1534,8 @@
                 blade_of_wizardry: false,
                 robe_elder_scribes: false,
                 blade_of_eternal_darkness: false,
+                sunwell_neck_aldor: false,
+                sunwell_neck_scryer: false,
                 mana_etched_4set: false,
                 meta_gem: 0,
                 trinket1: 0,
@@ -2463,6 +2476,9 @@
                 this.config.blade_of_wizardry = this.isEquipped("weapon", this.items.ids.BLADE_OF_WIZARDRY);
                 this.config.blade_of_eternal_darkness = this.isEquipped("weapon", this.items.ids.BLADE_OF_ETERNAL_DARKNESS);
                 this.config.robe_elder_scribes = this.isEquipped("chest", this.items.ids.ROBE_ELDER_SCRIBES);
+
+                this.config.sunwell_neck_aldor = (this.isEquipped("neck", this.items.ids.PENDANT_OF_ACUMEN) && this.config.shatt_faction == this.factions.FACTION_ALDOR);
+                this.config.sunwell_neck_scryer = (this.isEquipped("neck", this.items.ids.PENDANT_OF_ACUMEN) && this.config.shatt_faction == this.factions.FACTION_SCRYER);
 
                 if (this.isEquipped("neck", this.items.ids.EYE_OF_THE_NIGHT))
                     this.config.eye_of_the_night = true;

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -7,6 +7,10 @@ export default {
         RACE_TROLL: 4,
         RACE_UNDEAD: 5
     },
+    factions: {
+        FACTION_ALDOR: 0,
+        FACTION_SCRYER: 1
+    },
     regen_rotations: {
         REGEN_ROTATION_FB: 0,
         REGEN_ROTATION_AMFB: 1,

--- a/assets/js/items.js
+++ b/assets/js/items.js
@@ -45,6 +45,7 @@ var ids = {
     BURST_OF_KNOWLEDGE: 11832,
     DARK_IRON_PIPE: 38290,
     BLADE_OF_ETERNAL_DARKNESS: 17780,
+    PENDANT_OF_ACUMEN: 34678,
 };
 
 var equip = {
@@ -155,6 +156,7 @@ var equip = {
         { id: 22498, title: "Frostfire Circlet", int: 23, sp: 35, crit: 28, hit: 8 },
     ],
     neck: [
+        { id: 34678, title: "Shattered Sun Pendant of Acumen", int: 18, sp: 37, phase: 5 },
         { id: 34359, title: "Pendant of Sunfire", int: 19, sp: 34, crit: 25, haste: 25, sockets: ["y"], bonus: { sp: 2 }, phase: 5 },
         { id: 34204, title: "Amulet of Unfettered Magics", int: 17, sp: 39, hit: 15, haste: 32, phase: 5 },
         { id: 32349, title: "Translucent Spellthread Necklace", sp: 46, crit: 24, hit: 15, phase: 3 },

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -223,6 +223,8 @@ EMSCRIPTEN_BINDINGS(my_module) {
         .property("blade_of_wizardry", &Config::blade_of_wizardry)
         .property("robe_elder_scribes", &Config::robe_elder_scribes)
         .property("blade_of_eternal_darkness", &Config::blade_of_eternal_darkness)
+        .property("sunwell_neck_aldor", &Config::sunwell_neck_aldor)
+        .property("sunwell_neck_scryer", &Config::sunwell_neck_scryer)
 
         .property("trinket1", &Config::trinket1)
         .property("trinket2", &Config::trinket2)

--- a/src/buff.h
+++ b/src/buff.h
@@ -55,6 +55,7 @@ namespace buff
         FEL_ACHE = 38927,
         BURST_OF_KNOWLEDGE = 15646,
         DARK_IRON_PIPE = 51953,
+        LIGHTS_WRATH = 45479,
     };
 
 
@@ -759,6 +760,20 @@ namespace buff
         {
             id = BURST_OF_KNOWLEDGE;
             name = "Burst of Knowledge";
+            duration = 10;
+        }
+
+    };
+
+    // Shattered Sun Pendant of Acumen (Sunwell Neck: Aldor)
+    class LightsWrath : public Buff
+    {
+
+    public:
+        LightsWrath()
+        {
+            id = LIGHTS_WRATH;
+            name = "Light's Wrath";
             duration = 10;
         }
 

--- a/src/config.h
+++ b/src/config.h
@@ -68,6 +68,8 @@ struct Config
     bool blade_of_wizardry = false;
     bool robe_elder_scribes = false;
     bool blade_of_eternal_darkness = false;
+    bool sunwell_neck_aldor = false;
+    bool sunwell_neck_scryer = false;
 
     Trinket trinket1 = TRINKET_NONE;
     Trinket trinket2 = TRINKET_NONE;

--- a/src/cooldown.h
+++ b/src/cooldown.h
@@ -30,6 +30,8 @@ namespace cooldown
         CALL_OF_THE_NEXUS = 34320,
         FORGOTTEN_KNOWLEDGE = 38319,
         POWER_OF_ARCANAGOS = 34598,
+        LIGHTS_WRATH = 45479,
+        ARCANE_BOLT = 45429,
     };
 
 
@@ -336,6 +338,32 @@ namespace cooldown
         {
             id = POWER_OF_ARCANAGOS;
             duration = 50;
+        }
+
+    };
+
+    // Shattered Sun Pendant of Acumen (Sunwell Neck: Scryer)
+    class ArcaneBolt : public Cooldown
+    {
+
+    public:
+        ArcaneBolt()
+        {
+            id = ARCANE_BOLT;
+            duration = 45;
+        }
+
+    };
+
+    // Shattered Sun Pendant of Acumen (Sunwell Neck: Aldor)
+    class LightsWrath : public Cooldown
+    {
+
+    public:
+        LightsWrath()
+        {
+            id = LIGHTS_WRATH;
+            duration = 45;
         }
 
     };

--- a/src/simulation.h
+++ b/src/simulation.h
@@ -720,6 +720,18 @@ public:
             if (hasTrinket(TRINKET_DARKMOON_CRUSADE))
                 onBuffGain(make_shared<buff::DarkmoonCrusade>());
 
+            // 15% proc rate
+            if (config->sunwell_neck_scryer && !state->hasCooldown(cooldown::ARCANE_BOLT) && random<int>(0, 19) < 3) {
+                onCooldownGain(make_shared<cooldown::ArcaneBolt>());
+                cast(make_shared<spell::ArcaneBolt>());
+            }
+
+            // 15% proc rate
+            if (config->sunwell_neck_aldor && !state->hasCooldown(cooldown::LIGHTS_WRATH) && random<int>(0, 19) < 3) {
+                onBuffGain(make_shared<buff::LightsWrath>());
+                onCooldownGain(make_shared<cooldown::LightsWrath>());
+            }
+
             if (spell->result == spell::CRIT) {
                 // 20% proc rate
                 if (hasTrinket(TRINKET_UNSTABLE_CURRENTS) && !state->hasCooldown(cooldown::UNSTABLE_CURRENTS) && random<int>(0, 4) == 0) {
@@ -1843,6 +1855,8 @@ public:
                 sp+= 120.0;
             if (state->hasBuff(buff::DARKMOON_CRUSADE))
                 sp+= state->buffStacks(buff::DARKMOON_CRUSADE) * 8.0;
+            if (state->hasBuff(buff::LIGHTS_WRATH))
+                sp+= 120.0;
 
             if (state->hasBuff(buff::FEL_ACHE))
                 sp-= 25.0;

--- a/src/spell.h
+++ b/src/spell.h
@@ -14,6 +14,7 @@ namespace spell
         PYROBLAST = 33938,
         LIGHTNING_CAPACITOR = 28785,
         ENGULFING_SHADOWS = 21978,
+        ARCANE_BOLT = 45429,
     };
 
     enum Result : int
@@ -260,6 +261,25 @@ namespace spell
             max_dmg = 100;
             cast_time = 0;
             school = SCHOOL_SHADOW;
+            coeff = 0;
+            proc = true;
+        }
+    };
+
+    // Shattered Sun Pendant of Acumen (Sunwell Neck: Scryer)
+    class ArcaneBolt : public Spell
+    {
+
+    public:
+        ArcaneBolt()
+        {
+            id = ARCANE_BOLT;
+            name = "Arcane Bolt";
+            cost = 0;
+            min_dmg = 333;
+            max_dmg = 367;
+            cast_time = 0;
+            school = SCHOOL_ARCANE;
             coeff = 0;
             proc = true;
         }


### PR DESCRIPTION
Hey, I know you don't always like to add items well in advance, but I did the work this morning because it keeps coming up on mage disc and I was curious how the DPS compared. Figured I'd at least send it your way for a look. This is the necklace you can get in P5 for being exalted with the Shattered Sun Offensive, and has a different proc depending on whether you're Aldor or Scryer. I would have liked to make a different item for each faction but I couldn't find a way to do that cleanly since in-game it's one item with one ID. So I added a toggle for Aldor/Scryer faction instead.

I based the spell effects off the info from:
https://tbc.wowhead.com/item=34678/shattered-sun-pendant-of-acumen#comments
https://wowwiki-archive.fandom.com/wiki/Shattered_Sun_Pendant_of_Acumen